### PR TITLE
make: Disable cgo

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,6 +4,6 @@ clean:
 	-rm ./compliance
 
 Compliance:
-	go build -o compliance -buildvcs=false -v .
+	env CGO_ENABLED=0 go build -o compliance -buildvcs=false -v .
 
 .PHONY: clean


### PR DESCRIPTION
Use the `CGO_ENABLED=0` env variable to ensure that we are not dynamically linking glibc.

Signed-off-by: Michal Rostecki <vadorovsky@gmail.com>